### PR TITLE
docs: Q2 2026 financial reports (March–May) and QVE-2026-0001

### DIFF
--- a/financial-reports/2026-04-09-march-2026.md
+++ b/financial-reports/2026-04-09-march-2026.md
@@ -1,0 +1,110 @@
+# Financial Reporting March 2026
+For March 2026 a total of `113'819'834'508 Qubic` have been paid out.
+
+For the payments made on the 05.04.2026, `113'819'834'438 Qubic` have been valued at `903/bln`.<br>
+
+70 Qubic were spent in the Send to Many Transfers execution fees.<br>
+
+> Total expenses for March were: **102'779.31 $** (paid until 05.04.2026)
+
+## Cost Breakdown
+
+<div style="display: flex; justify-content: center; align-items: center; gap: 10px;flex-wrap:wrap;">
+<div>
+
+ ```mermaid
+pie title Categories
+"Salaries":93.2614265204300
+"Infrastructure":6.7385734795600
+```
+
+</div>
+ <div>
+
+ ```mermaid
+pie title Categories
+"Core":44.1879553201900
+"Integration":21.5173441505500
+"Testing":5.0107356226900
+"Operation":0
+"Overhead":19.1400371203000
+"Infrastructure":6.7385734795600
+"Client":3.4053543066800
+```
+
+ </div>
+</div>
+
+## Budget View
+> Total available budget for March 2026 - June 2026: `572'000'000'000 Qubic`.
+
+<div style="display: flex; justify-content: center; align-items: center; gap: 10px;flex-wrap:wrap;">
+<div>
+
+```mermaid
+pie title Qubic
+"Used":19.89
+"Open":80.11
+```
+
+ </div>
+</div>
+
+## Included Salaries
+Because not all team members receive a fixed salary and they send reports on their worked hours, the monthly budget for salaries fluctuate.<br>
+The above numbers include the salaries for March 2026 of the following persons (alphabetical order):
+
+```
+alez
+cyber-pc
+dkat
+feiyu.IV
+fnordspace
+kavatak
+keta
+kimz300
+linckode
+luk
+mio
+Mr.Rose
+phil
+raika sternensucher
+sally
+yurabb8
+```
+
+## Transactions
+
+
+|    # | Date       | Target Month | Wallet             | Category               | $-Qubic/b |   Amount $ |   Amount Qubic | TX Link                                                                                            |
+| ---: | :--------- | :----------- | :----------------- | :--------------------- | --------: | ---------: | -------------: | :------------------------------------------------------------------------------------------------- |
+|    1 | 05.04.2026 | March        | QCT-Core           | Salary                 |       903 |  $4'000.00 |  4'429'678'848 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|    2 | 05.04.2026 | March        | QCT-Core           | Salary                 |       903 | $13'273.91 | 14'699'789'590 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|    3 | 05.04.2026 | March        | QCT-Core           | Salary                 |       903 |  $5'000.00 |  5'537'098'560 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|    4 | 05.04.2026 | March        | QCT-Core           | Salary                 |       903 | $11'299.17 | 12'512'924'142 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|    5 | 05.04.2026 | March        | QCT-Core           | Salary                 |       903 |  $8'682.50 |  9'615'171'650 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|    6 | 05.04.2026 | March        | QCT-Core           | Salary                 |       903 |  $3'160.50 |  3'500'000'000* | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|    7 | 05.04.2026 | March        | QCT-Overhead       | Salary                 |       903 |  $6'000.00 |  6'644'518'272 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|    8 | 05.04.2026 | March        | QCT-Overhead       | Salary                 |       903 |  $2'500.00 |  2'768'549'280 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|    9 | 05.04.2026 | March        | QCT-Overhead       | Salary                 |       903 | $11'172.00 | 12'372'093'023 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|   10 | 05.04.2026 | March        | QCT-Client         | Salary                 |       903 |  $1'500.00 |  1'661'129'568 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|   11 | 05.04.2026 | March        | QCT-Client         | Salary                 |       903 |  $2'000.00 |  2'214'839'424 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|   12 | 05.04.2026 | March        | QCT-Infrastructure | Server                 |       903 |    $805.81 |    892'364'341 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|   13 | 05.04.2026 | March        | QCT-Infrastructure | Server                 |       903 |  $1'196.00 |  1'324'473'976 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|   14 | 05.04.2026 | March        | QCT-Infrastructure | Services               |       903 |    $255.20 |    282'613'511 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|   15 | 05.04.2026 | March        | QCT-Infrastructure | Services               |       903 |  $1'100.00 |  1'218'161'683 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|   16 | 05.04.2026 | March        | QCT-Infrastructure | Services               |       903 |  $2'000.00 |  2'214'839'424 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|   17 | 05.04.2026 | March        | QCT-Infrastructure | Services               |       903 |    $318.85 |    353'100'775 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|   18 | 05.04.2026 | March        | QCT-Integration    | Salary                 |       903 |  $6'160.00 |  6'821'705'426 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|   19 | 05.04.2026 | March        | QCT-Integration    | Salary                 |       903 |    $248.33 |    275'000'000* | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|   20 | 05.04.2026 | March        | QCT-Integration    | Salary                 |       903 |  $2'107.05 |  2'333'388'704 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|   21 | 05.04.2026 | March        | QCT-Integration    | Salary                 |       903 | $13'600.00 | 15'060'908'084 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|   22 | 05.04.2026 | March        | QCT-Testing        | Salary                 |       903 |  $3'150.00 |  3'488'372'093 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|   23 | 05.04.2026 | March        | QCT-Testing        | Salary                 |       903 |  $2'000.00 |  2'214'839'424 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+|   24 | 05.04.2026 | March        | QCT-Infrastructure | Services               |       903 |  $1'250.00 |  1'384'274'640 | https://explorer.qubic.org/network/tx/trhkgrpupfmwjbfqztvfijyhoqpakgwbrrfecvzxbduvetelspokqmkhlfwg |
+
+*Transactions #6 and #19: Fixed Qubic amounts agreed in advance; USD values are indicative only.
+
+### Current Balance
+
+> Balance after payments: `458'180'165'492 Qubic`<br>

--- a/financial-reports/2026-06-09-april-2026.md
+++ b/financial-reports/2026-06-09-april-2026.md
@@ -1,0 +1,121 @@
+# Financial Reporting April 2026
+For April 2026 a total of `159'742'449'783 Qubic` have been paid out.
+
+For the payments made on the 05.05.2026, `159'742'449'713 Qubic` have been valued at `590/bln`.<br>
+
+70 Qubic were spent in the Send to Many Transfers execution fees.<br>
+
+> Total expenses for April were: **94'248.05 $** (paid until 05.05.2026)
+
+## Cost Breakdown
+
+<div style="display: flex; justify-content: center; align-items: center; gap: 10px;flex-wrap:wrap;">
+<div>
+
+ ```mermaid
+pie title Categories
+"Salaries":91.7726697962963
+"Infrastructure":8.22733020370371
+```
+
+</div>
+ <div>
+
+ ```mermaid
+pie title Categories
+"Core":44.2734215707204
+"Integration":17.1642657871732
+"Testing":5.46430430663947
+"Operation":0
+"Overhead":21.1570732631733
+"Infrastructure":8.22733020370371
+"Client":3.71360486858993
+```
+
+ </div>
+</div>
+
+## Budget View
+> Total available budget for March 2026 - June 2026: `572'000'000'000 Qubic`.
+
+<div style="display: flex; justify-content: center; align-items: center; gap: 10px;flex-wrap:wrap;">
+<div>
+
+```mermaid
+pie title Qubic
+"Used":50.17
+"Open":49.83
+```
+
+ </div>
+</div>
+
+## Included Salaries
+Because not all team members receive a fixed salary and they send reports on their worked hours, the monthly budget for salaries fluctuate.<br>
+The above numbers include the salaries for April 2026 of the following persons (alphabetical order):
+
+```
+alez
+cyber-pc
+dkat
+feiyu.IV
+fnordspace
+kavatak
+keta
+kimz300
+linckode
+luk
+mio
+Mr.Rose
+phil
+raika sternensucher
+sally
+yurabb8
+```
+
+## Transactions
+
+
+|    # | Date       | Target Month | Wallet             | Category               | $-Qubic/b |   Amount $ |   Amount Qubic | TX Link                                                                                            |
+| ---: | :--------- | :----------- | :----------------- | :--------------------- | --------: | ---------: | -------------: | :------------------------------------------------------------------------------------------------- |
+|    1 | 05.05.2026 | April        | QCT-Core           | Salary                 |       590 |  $4'000.00 |  6'779'661'017 | https://explorer.qubic.org/network/tx/lfrxrspxldwgzggqvpwmzefbkdlfvsxdxdjwmdwfudoioyfuejvvxuhgzjgm |
+|    2 | 05.05.2026 | April        | QCT-Core           | Salary                 |       590 | $13'592.48 | 23'038'108'203 | https://explorer.qubic.org/network/tx/lfrxrspxldwgzggqvpwmzefbkdlfvsxdxdjwmdwfudoioyfuejvvxuhgzjgm |
+|    3 | 05.05.2026 | April        | QCT-Core           | Salary                 |       590 |  $5'000.00 |  8'474'576'271 | https://explorer.qubic.org/network/tx/lfrxrspxldwgzggqvpwmzefbkdlfvsxdxdjwmdwfudoioyfuejvvxuhgzjgm |
+|    4 | 05.05.2026 | April        | QCT-Core           | Salary                 |       590 | $11'570.35 | 19'610'763'715 | https://explorer.qubic.org/network/tx/lfrxrspxldwgzggqvpwmzefbkdlfvsxdxdjwmdwfudoioyfuejvvxuhgzjgm |
+|    5 | 05.05.2026 | April        | QCT-Core           | Salary                 |       590 |  $5'499.00 |  9'320'338'983 | https://explorer.qubic.org/network/tx/lfrxrspxldwgzggqvpwmzefbkdlfvsxdxdjwmdwfudoioyfuejvvxuhgzjgm |
+|    6 | 05.05.2026 | April        | QCT-Core           | Salary                 |       590 |  $2'065.00 |  3'500'000'000* | https://explorer.qubic.org/network/tx/lfrxrspxldwgzggqvpwmzefbkdlfvsxdxdjwmdwfudoioyfuejvvxuhgzjgm |
+|    7 | 05.05.2026 | April        | QCT-Overhead       | Salary                 |       590 |  $6'000.00 | 10'169'491'525 | https://explorer.qubic.org/network/tx/oplphpgqcyrncbltlqsgmifszdycwunjpifjdccqfdqeudvbjxdonxudzkam |
+|    8 | 05.05.2026 | April        | QCT-Overhead       | Salary                 |       590 |  $2'500.00 |  4'237'288'136 | https://explorer.qubic.org/network/tx/oplphpgqcyrncbltlqsgmifszdycwunjpifjdccqfdqeudvbjxdonxudzkam |
+|    9 | 05.05.2026 | April        | QCT-Overhead       | Salary                 |       590 | $11'440.13 | 19'390'047'458 | https://explorer.qubic.org/network/tx/oplphpgqcyrncbltlqsgmifszdycwunjpifjdccqfdqeudvbjxdonxudzkam |
+|   10 | 05.05.2026 | April        | QCT-Client         | Salary                 |       590 |  $1'500.00 |  2'542'372'881 | https://explorer.qubic.org/network/tx/zufwzzcxjxlcbedwelkpytmulewbckvwawqrfwyylbrjlqpvibwfgqbcmfla |
+|   11 | 05.05.2026 | April        | QCT-Client         | Salary                 |       590 |  $2'000.00 |  3'389'830'508 | https://explorer.qubic.org/network/tx/zufwzzcxjxlcbedwelkpytmulewbckvwawqrfwyylbrjlqpvibwfgqbcmfla |
+|   12 | 05.05.2026 | April        | QCT-Infrastructure | Server                 |       590 |    $753.56 |  1'277'223'559 | https://explorer.qubic.org/network/tx/qafsbocnebwszcyzkjqxzxnbusfcwlogexdoxshowbxbwueisfyhmfwfwtfd |
+|   13 | 05.05.2026 | April        | QCT-Infrastructure | Server                 |       590 |  $1'216.80 |  2'062'372'881 | https://explorer.qubic.org/network/tx/qafsbocnebwszcyzkjqxzxnbusfcwlogexdoxshowbxbwueisfyhmfwfwtfd |
+|   14 | 05.05.2026 | April        | QCT-Infrastructure | Services               |       590 |    $265.00 |    449'149'831 | https://explorer.qubic.org/network/tx/qafsbocnebwszcyzkjqxzxnbusfcwlogexdoxshowbxbwueisfyhmfwfwtfd |
+|   15 | 05.05.2026 | April        | QCT-Infrastructure | Services               |       590 |  $1'100.00 |  1'864'406'780 | https://explorer.qubic.org/network/tx/qafsbocnebwszcyzkjqxzxnbusfcwlogexdoxshowbxbwueisfyhmfwfwtfd |
+|   16 | 05.05.2026 | April        | QCT-Infrastructure | Services               |       590 |  $2'000.00 |  3'389'830'508 | https://explorer.qubic.org/network/tx/qafsbocnebwszcyzkjqxzxnbusfcwlogexdoxshowbxbwueisfyhmfwfwtfd |
+|   17 | 05.05.2026 | April        | QCT-Integration    | Salary                 |       590 |  $4'760.00 |  8'067'796'610 | https://explorer.qubic.org/network/tx/zpsgbyjhxlydtbgxxcipuwlvdmdfhgtedomtebxoddllnudidhtdcyrbsngj |
+|   18 | 05.05.2026 | April        | QCT-Integration    | Salary                 |       590 |    $125.38 |    212'500'000* | https://explorer.qubic.org/network/tx/zpsgbyjhxlydtbgxxcipuwlvdmdfhgtedomtebxoddllnudidhtdcyrbsngj |
+|   19 | 05.05.2026 | April        | QCT-Integration    | Salary                 |       590 |  $1'491.61 |  2'528'152'542 | https://explorer.qubic.org/network/tx/zpsgbyjhxlydtbgxxcipuwlvdmdfhgtedomtebxoddllnudidhtdcyrbsngj |
+|   20 | 05.05.2026 | April        | QCT-Integration    | Salary                 |       590 |  $9'800.00 | 16'610'169'492 | https://explorer.qubic.org/network/tx/zpsgbyjhxlydtbgxxcipuwlvdmdfhgtedomtebxoddllnudidhtdcyrbsngj |
+|   21 | 05.05.2026 | April        | QCT-Testing        | Salary                 |       590 |  $3'150.00 |  5'338'983'051 | https://explorer.qubic.org/network/tx/aihjwqhayestvaqdeaqcsvtpbpngxkjbqjkuznpcihzrdabgljicuiucjdte |
+|   22 | 05.05.2026 | April        | QCT-Testing        | Salary                 |       590 |  $2'000.00 |  3'389'830'508 | https://explorer.qubic.org/network/tx/aihjwqhayestvaqdeaqcsvtpbpngxkjbqjkuznpcihzrdabgljicuiucjdte |
+|   23 | 05.05.2026 | April        | QCT-Infrastructure | Services               |       590 |  $1'280.00 |  2'169'491'525 | https://explorer.qubic.org/network/tx/qafsbocnebwszcyzkjqxzxnbusfcwlogexdoxshowbxbwueisfyhmfwfwtfd |
+|   24 | 05.05.2026 | April        | QCT-Infrastructure | Server                 |       590 |    $577.21 |    978'318'305 | https://explorer.qubic.org/network/tx/qafsbocnebwszcyzkjqxzxnbusfcwlogexdoxshowbxbwueisfyhmfwfwtfd |
+|   25 | 05.05.2026 | April        | QCT-Infrastructure | Server                 |       590 |    $561.53 |    951'745'424 | https://explorer.qubic.org/network/tx/qafsbocnebwszcyzkjqxzxnbusfcwlogexdoxshowbxbwueisfyhmfwfwtfd |
+
+*Transactions #6 and #18: Fixed Qubic amounts agreed in advance; USD values are indicative only.
+
+### Other Transfers
+
+In addition to the regular monthly payments, a one-off transfer was made from the QCT treasury on 17.04.2026 to a dedicated wallet to compensate MEXC for losses caused by an integration-layer incident. This is **not** part of the operational cost breakdown above.
+
+| Date       | From         | To                                                                 | Amount Qubic   | TX Link                                                                                            | Reference                          |
+| :--------- | :----------- | :----------------------------------------------------------------- | -------------: | :------------------------------------------------------------------------------------------------- | :--------------------------------- |
+| 17.04.2026 | QCT-Treasury | JXSQGHDICVEBEAGVGFTSSNUORXLCEBBROYMXHTPYDEIPBMXQRFPFYNPFMVUN       | 13'391'819'438 | https://explorer.qubic.org/network/tx/tkjfwrbmupgjncjoukqdjevknctfsdlfnoaylvozhdjmwstokggwuuehvblj | [QVE-2026-0001](../qve/QVE-2026-0001.md) |
+
+See [QVE-2026-0001](../qve/QVE-2026-0001.md) for full incident details, root cause, mitigation, and funding sources.
+
+### Current Balance
+
+> Balance after payments (including 17.04 reimbursement): `285'045'896'271 Qubic`<br>

--- a/financial-reports/2026-06-09-may-2026.md
+++ b/financial-reports/2026-06-09-may-2026.md
@@ -1,0 +1,113 @@
+# Financial Reporting May 2026
+For May 2026 a total of `185'484'580'100 Qubic` have been paid out.
+
+For the payments made on the 05.06.2026, `185'484'580'030 Qubic` have been valued at `470/bln`.<br>
+
+70 Qubic were spent in the Send to Many Transfers execution fees.<br>
+
+> Total expenses for May were: **87'177.75 $** (paid until 05.06.2026)
+
+## Cost Breakdown
+
+<div style="display: flex; justify-content: center; align-items: center; gap: 10px;flex-wrap:wrap;">
+<div>
+
+ ```mermaid
+pie title Categories
+"Salaries":92.3764689949891
+"Infrastructure":7.62353100501091
+```
+
+</div>
+ <div>
+
+ ```mermaid
+pie title Categories
+"Core":42.1522937471305
+"Integration":17.634007288611
+"Testing":5.90747047908293
+"Operation":0
+"Overhead":22.6679117176812
+"Infrastructure":7.62353100501091
+"Client":4.01478576248355
+```
+
+ </div>
+</div>
+
+## Budget View
+> Total available budget for March 2026 - June 2026: `572'000'000'000 Qubic`.
+
+<div style="display: flex; justify-content: center; align-items: center; gap: 10px;flex-wrap:wrap;">
+<div>
+
+```mermaid
+pie title Qubic
+"Used":82.59
+"Open":17.41
+```
+
+ </div>
+</div>
+
+## Included Salaries
+Because not all team members receive a fixed salary and they send reports on their worked hours, the monthly budget for salaries fluctuate.<br>
+The above numbers include the salaries for May 2026 of the following persons (alphabetical order):
+
+```
+alez
+cyber-pc
+dkat
+feiyu.IV
+fnordspace
+kavatak
+keta
+kimz300
+linckode
+luk
+mio
+Mr.Rose
+phil
+raika sternensucher
+sally
+yurabb8
+```
+
+## Transactions
+
+
+|    # | Date       | Target Month | Wallet             | Category               | $-Qubic/b |   Amount $ |   Amount Qubic | TX Link                                                                                            |
+| ---: | :--------- | :----------- | :----------------- | :--------------------- | --------: | ---------: | -------------: | :------------------------------------------------------------------------------------------------- |
+|    1 | 05.06.2026 | May          | QCT-Core           | Salary                 |       470 |  $4'000.00 |  8'510'638'298 | https://explorer.qubic.org/network/tx/bfafasdzfjgkwetdydndeauizudfippqlyublvksbhuczaeukvjclieefoye |
+|    2 | 05.06.2026 | May          | QCT-Core           | Salary                 |       470 | $11'435.36 | 24'330'550'000 | https://explorer.qubic.org/network/tx/bfafasdzfjgkwetdydndeauizudfippqlyublvksbhuczaeukvjclieefoye |
+|    3 | 05.06.2026 | May          | QCT-Core           | Salary                 |       470 |  $5'000.00 | 10'638'297'872 | https://explorer.qubic.org/network/tx/bfafasdzfjgkwetdydndeauizudfippqlyublvksbhuczaeukvjclieefoye |
+|    4 | 05.06.2026 | May          | QCT-Core           | Salary                 |       470 | $11'389.56 | 24'233'114'604 | https://explorer.qubic.org/network/tx/bfafasdzfjgkwetdydndeauizudfippqlyublvksbhuczaeukvjclieefoye |
+|    5 | 05.06.2026 | May          | QCT-Core           | Salary                 |       470 |  $3'277.50 |  6'973'404'255 | https://explorer.qubic.org/network/tx/bfafasdzfjgkwetdydndeauizudfippqlyublvksbhuczaeukvjclieefoye |
+|    6 | 05.06.2026 | May          | QCT-Core           | Salary                 |       470 |  $1'645.00 |  3'500'000'000* | https://explorer.qubic.org/network/tx/bfafasdzfjgkwetdydndeauizudfippqlyublvksbhuczaeukvjclieefoye |
+|    7 | 05.06.2026 | May          | QCT-Overhead       | Salary                 |       470 |  $6'000.00 | 12'765'957'447 | https://explorer.qubic.org/network/tx/emnxdsjtpwgovapexzbrnlroejyflvrxsydqqtucdbfgwwkwqbcmjttctbam |
+|    8 | 05.06.2026 | May          | QCT-Overhead       | Salary                 |       470 |  $2'500.00 |  5'319'148'936 | https://explorer.qubic.org/network/tx/emnxdsjtpwgovapexzbrnlroejyflvrxsydqqtucdbfgwwkwqbcmjttctbam |
+|    9 | 05.06.2026 | May          | QCT-Overhead       | Salary                 |       470 | $11'261.38 | 23'960'374'468 | https://explorer.qubic.org/network/tx/emnxdsjtpwgovapexzbrnlroejyflvrxsydqqtucdbfgwwkwqbcmjttctbam |
+|   10 | 05.06.2026 | May          | QCT-Client         | Salary                 |       470 |  $1'500.00 |  3'191'489'362 | https://explorer.qubic.org/network/tx/gfamlovsklymngzljsfpdrmjzzbexywmzcmksrljkempssywkvcazxkbdoci |
+|   11 | 05.06.2026 | May          | QCT-Client         | Salary                 |       470 |  $2'000.00 |  4'255'319'149 | https://explorer.qubic.org/network/tx/gfamlovsklymngzljsfpdrmjzzbexywmzcmksrljkempssywkvcazxkbdoci |
+|   12 | 05.06.2026 | May          | QCT-Infrastructure | Server                 |       470 |  $1'039.77 |  2'212'281'915 | https://explorer.qubic.org/network/tx/xsrjgvnjueaftezknyukjvkrarrbyfdwnebmljkemaakohyevzvlpkhghzef |
+|   13 | 05.06.2026 | May          | QCT-Infrastructure | Server                 |       470 |  $1'007.94 |  2'144'554'255 | https://explorer.qubic.org/network/tx/xsrjgvnjueaftezknyukjvkrarrbyfdwnebmljkemaakohyevzvlpkhghzef |
+|   14 | 05.06.2026 | May          | QCT-Infrastructure | Services               |       470 |    $263.15 |    559'895'745 | https://explorer.qubic.org/network/tx/xsrjgvnjueaftezknyukjvkrarrbyfdwnebmljkemaakohyevzvlpkhghzef |
+|   15 | 05.06.2026 | May          | QCT-Infrastructure | Services               |       470 |  $1'100.00 |  2'340'425'532 | https://explorer.qubic.org/network/tx/xsrjgvnjueaftezknyukjvkrarrbyfdwnebmljkemaakohyevzvlpkhghzef |
+|   16 | 05.06.2026 | May          | QCT-Infrastructure | Services               |       470 |  $2'000.00 |  4'255'319'149 | https://explorer.qubic.org/network/tx/xsrjgvnjueaftezknyukjvkrarrbyfdwnebmljkemaakohyevzvlpkhghzef |
+|   17 | 05.06.2026 | May          | QCT-Integration    | Salary                 |       470 |  $3'850.00 |  8'191'489'362 | https://explorer.qubic.org/network/tx/xxcgqxjxxzkgrcnrfxdjviosbuahkcbzwfbwzehcbaeskmqmphffctefvzvb |
+|   18 | 05.06.2026 | May          | QCT-Integration    | Salary                 |       470 |     $80.78 |    171'875'000* | https://explorer.qubic.org/network/tx/xxcgqxjxxzkgrcnrfxdjviosbuahkcbzwfbwzehcbaeskmqmphffctefvzvb |
+|   19 | 05.06.2026 | May          | QCT-Integration    | Salary                 |       470 |  $1'742.15 |  3'706'702'128 | https://explorer.qubic.org/network/tx/xxcgqxjxxzkgrcnrfxdjviosbuahkcbzwfbwzehcbaeskmqmphffctefvzvb |
+|   20 | 05.06.2026 | May          | QCT-Integration    | Salary                 |       470 |  $9'700.00 | 20'638'297'872 | https://explorer.qubic.org/network/tx/xxcgqxjxxzkgrcnrfxdjviosbuahkcbzwfbwzehcbaeskmqmphffctefvzvb |
+|   21 | 05.06.2026 | May          | QCT-Testing        | Salary                 |       470 |  $3'150.00 |  6'702'127'660 | https://explorer.qubic.org/network/tx/rpkwqudyhcwougyomnxrnechhhabvaysecbzthzozbtwdkxxctxzvlkesgph |
+|   22 | 05.06.2026 | May          | QCT-Testing        | Salary                 |       470 |  $2'000.00 |  4'255'319'149 | https://explorer.qubic.org/network/tx/rpkwqudyhcwougyomnxrnechhhabvaysecbzthzozbtwdkxxctxzvlkesgph |
+|   23 | 05.06.2026 | May          | QCT-Infrastructure | Server                 |       470 |    $624.98 |  1'329'742'553 | https://explorer.qubic.org/network/tx/xsrjgvnjueaftezknyukjvkrarrbyfdwnebmljkemaakohyevzvlpkhghzef |
+|   24 | 05.06.2026 | May          | QCT-Infrastructure | Services               |       470 |    $560.18 |  1'191'872'340 | https://explorer.qubic.org/network/tx/xsrjgvnjueaftezknyukjvkrarrbyfdwnebmljkemaakohyevzvlpkhghzef |
+|   25 | 05.06.2026 | May          | QCT-Infrastructure | Services               |       470 |     $50.00 |    106'382'979 | https://explorer.qubic.org/network/tx/xsrjgvnjueaftezknyukjvkrarrbyfdwnebmljkemaakohyevzvlpkhghzef |
+
+*Transactions #6 and #18: Fixed Qubic amounts agreed in advance; USD values are indicative only.
+
+### Current Balance
+
+> Balance after payments: `99'561'316'171 Qubic`<br>
+
+> The remaining treasury balance of `99'561'316'171 Qubic` (~$46'794 at `470 USD/bln`) will not be sufficient to cover the June 2026 expenses. The current budget of `572'000'000'000 Qubic` was approved for the period March 2026 – June 2026 (4 months) at a valuation of `700 USD/bln`. Due to the lower valuation of Qubic, a new funding proposal will be submitted to cover June 2026 expenses and operations beyond.

--- a/qve/QVE-2026-0001.md
+++ b/qve/QVE-2026-0001.md
@@ -1,0 +1,94 @@
+# QVE-2026-0001: Incident: Query API Returning False Failure Status for Successful Transactions
+
+**Date Reported:** 2026-04-13
+**Status:** Resolved
+**Severity:** Critical
+
+## Description
+A transaction-status data processing issue in the ecosystem integration infrastructure caused the Query API to report successful transactions as failed. End users, seeing their withdrawals marked as failed, manually resubmitted them — unaware that the original transactions had actually been processed and their funds already sent. MEXC, other exchanges, and users reported the issue on April 13th and 14th, 2026. While multiple parties were affected, MEXC was the only exchange that required compensation, as their affected withdrawals had already left the exchange to end users with no possibility to reverse them.
+
+## Impact
+Three groups of transactions were affected, resulting in a total overpayment of `17'338'799'372 Qubic` to three end users.
+
+| Group | Destination                                                  | Amount per TX | Total TXs | Legitimate | Duplicates |   Duplicate Amount |
+| ----: | :----------------------------------------------------------- | ------------: | --------: | ---------: | ---------: | -----------------: |
+|     1 | DIYJVZMAGAFLIFHEOCBLUEIEIODBWTGVDQGRYLQBOCOPIMDHRDZPYPAABUNB |   657'829'989 |         7 |          1 |          6 |      3'946'979'934 |
+|     2 | MUWTREOPIYTWIALVEEASVHHSJBGBLPOUJKHDKLXYHDAZZSGDCZNJNFSGSKYJ | 2'139'184'250 |         7 |          1 |          6 |     12'835'105'500 |
+|     3 | GUVNFCBFXEWMUENNUKXGHVOHXJLAUBIYTMHOKZNETALBZBJHMUNERPDGVBGL |   278'356'969 |         3 |          1 |          2 |        556'713'938 |
+|       |                                                              |               |    **17** |      **3** |     **14** | **17'338'799'372** |
+
+All duplicate transactions originated from the MEXC hot wallet (VUEYKUCYYHXKDGOSCWAIEECECDBCXVUSUAJRVXUQVAQPGIOABLGGLXDAXTNK) on 2026-04-13 between 12:07 and 12:44 UTC.
+
+## Root Cause
+
+> [!IMPORTANT]
+> This was not a blockchain or consensus error. The Qubic blockchain state, transaction finality, and cryptographic verification were not affected.
+
+The root cause was that some trusted core nodes returned unexpected empty responses for certain ticks when serving transaction status data via the `moneyFlew` flag (from the core node's TX Status addon). The flag is inherently trust-based — it cannot be fully validated by downstream consumers, only sanity-checked.
+
+A contributing factor was that the integration layer did not have sufficient sanity checks in place to detect these unexpected responses in time. The Archiver treated the empty responses as "all transactions failed" in the affected ticks, which propagated through the Query API, leading exchange users to resubmit withdrawals.
+
+## Mitigation / Fix
+Additional sanity checks have been implemented in the Archiver to detect empty responses from core nodes, preventing them from being incorrectly interpreted as failed transactions.
+
+Subsequent missing-transaction-info issues from the TX Status addon were also identified and addressed by the core team in [qubic/core#848](https://github.com/qubic/core/pull/848).
+
+## Actions Taken
+- Acknowledged the error in processing blockchain data and compensated MEXC for the losses (see [Compensation](#compensation) below). Prompt compensation was provided to minimize disruption to Qubic operations on the exchange.
+- Requested MEXC's assistance in recovering funds from the remaining end users (Groups 2 and 3). MEXC reported that these users had already traded or transacted the received funds, making recovery not possible. This is why the remaining compensation had to be covered from QCT budget.
+
+## Planned Improvements
+- Migrate away from the core node's TX Status addon. The integration team will compute transaction status using data from multiple BOB nodes, providing redundancy and reducing dependency on a single source.
+- A new tutorial will be created for exchanges on how to run their own BOB nodes, enabling them to independently verify transaction status.
+
+## Duplicate Transactions
+
+### Group 1 — Destination: DIYJVZMAGAFLIFHEOCBLUEIEIODBWTGVDQGRYLQBOCOPIMDHRDZPYPAABUNB (657'829'989 Qubic each)
+
+|    # | Timestamp (UTC)     |     Tick | TX ID                                                                                                                                                              |
+| ---: | :------------------ | -------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    1 | 2026-04-13 12:14:15 | 49271411 | [hrpakbympspwwdqmkdywpgnvhohfjkmcoedoysoklaklajawefhrdcpdnoig](https://explorer.qubic.org/network/tx/hrpakbympspwwdqmkdywpgnvhohfjkmcoedoysoklaklajawefhrdcpdnoig) |
+|    2 | 2026-04-13 12:16:11 | 49271602 | [sevwvgbnicszhfofdnfmswmfwlpcrvqdqimhzwyvjadetnvhbhrhyfeedzic](https://explorer.qubic.org/network/tx/sevwvgbnicszhfofdnfmswmfwlpcrvqdqimhzwyvjadetnvhbhrhyfeedzic) |
+|    3 | 2026-04-13 12:18:10 | 49271788 | [grvyzpwepgkbdcrqtoobsxrlnaqfwrckeuzzqpssgcadoidmfbdlbtobbyni](https://explorer.qubic.org/network/tx/grvyzpwepgkbdcrqtoobsxrlnaqfwrckeuzzqpssgcadoidmfbdlbtobbyni) |
+|    4 | 2026-04-13 12:20:05 | 49272005 | [lklwmthkgusreesnrouajhbwfoxasiaflsleobwledpnlmzbkiugecvcaawo](https://explorer.qubic.org/network/tx/lklwmthkgusreesnrouajhbwfoxasiaflsleobwledpnlmzbkiugecvcaawo) |
+|    5 | 2026-04-13 12:22:05 | 49272211 | [tvsaswblutfshdusquoqyeqoxftbivnjhnglwppuwastmogmvxpagewczrmi](https://explorer.qubic.org/network/tx/tvsaswblutfshdusquoqyeqoxftbivnjhnglwppuwastmogmvxpagewczrmi) |
+|    6 | 2026-04-13 12:24:09 | 49272411 | [cwvlblmcvifhzbqpcqggpbvquyqebonwqrlkfxnaqbniyjzrgypvewufaizk](https://explorer.qubic.org/network/tx/cwvlblmcvifhzbqpcqggpbvquyqebonwqrlkfxnaqbniyjzrgypvewufaizk) |
+|    7 | 2026-04-13 12:26:07 | 49272640 | [wphqdrkvrqohefvvjzgydypxvfngzliiogrmqtsbrfrsvmxilinvtxpgtbmo](https://explorer.qubic.org/network/tx/wphqdrkvrqohefvvjzgydypxvfngzliiogrmqtsbrfrsvmxilinvtxpgtbmo) |
+
+### Group 2 — Destination: MUWTREOPIYTWIALVEEASVHHSJBGBLPOUJKHDKLXYHDAZZSGDCZNJNFSGSKYJ (2'139'184'250 Qubic each)
+
+|    # | Timestamp (UTC)     |     Tick | TX ID                                                                                                                                                              |
+| ---: | :------------------ | -------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    1 | 2026-04-13 12:07:11 | 49270723 | [csuvrfallglgjauqogpmgkolxnxayqvtlyzknbxxuamuvnsaeerznevfzkhd](https://explorer.qubic.org/network/tx/csuvrfallglgjauqogpmgkolxnxayqvtlyzknbxxuamuvnsaeerznevfzkhd) |
+|    2 | 2026-04-13 12:09:11 | 49270919 | [ecmbmngbcgssyfriensppatqyfpeyaotxmsugpzmreishnolssbjtoagitpj](https://explorer.qubic.org/network/tx/ecmbmngbcgssyfriensppatqyfpeyaotxmsugpzmreishnolssbjtoagitpj) |
+|    3 | 2026-04-13 12:11:09 | 49271093 | [nsbkinjgctylqdwmdtgnsuoafbxgcxzcfneqrpwjadksjkoijakhwofdvssj](https://explorer.qubic.org/network/tx/nsbkinjgctylqdwmdtgnsuoafbxgcxzcfneqrpwjadksjkoijakhwofdvssj) |
+|    4 | 2026-04-13 12:13:05 | 49271295 | [tfssdocrznhkkabqjbfkwiwqgnrgrdrndptlytkcqdkzozkpvcqcxxugmsam](https://explorer.qubic.org/network/tx/tfssdocrznhkkabqjbfkwiwqgnrgrdrndptlytkcqdkzozkpvcqcxxugmsam) |
+|    5 | 2026-04-13 12:15:08 | 49271498 | [xjqcxlbbzjqfuboxtxfhuerslejczzaiqujrbfaplapdgwwqdsddlpzcwgji](https://explorer.qubic.org/network/tx/xjqcxlbbzjqfuboxtxfhuerslejczzaiqujrbfaplapdgwwqdsddlpzcwgji) |
+|    6 | 2026-04-13 12:17:07 | 49271685 | [fagqsbjtyapqpakucelrzfljpmrclhedairgumhvhasykakrhsctqhgastpm](https://explorer.qubic.org/network/tx/fagqsbjtyapqpakucelrzfljpmrclhedairgumhvhasykakrhsctqhgastpm) |
+|    7 | 2026-04-13 12:19:07 | 49271895 | [pefatauayrgeraxfopytzdkudzbdljkciiwkcaiswgoiszoelmcymihfzzjn](https://explorer.qubic.org/network/tx/pefatauayrgeraxfopytzdkudzbdljkciiwkcaiswgoiszoelmcymihfzzjn) |
+
+### Group 3 — Destination: GUVNFCBFXEWMUENNUKXGHVOHXJLAUBIYTMHOKZNETALBZBJHMUNERPDGVBGL (278'356'969 Qubic each)
+
+|    # | Timestamp (UTC)     |     Tick | TX ID                                                                                                                                                              |
+| ---: | :------------------ | -------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    1 | 2026-04-13 12:40:12 | 49274058 | [jryaziiucehhehqerjivnerqumrehsnnvbzqwlibdbtajliydtvfstedwbtn](https://explorer.qubic.org/network/tx/jryaziiucehhehqerjivnerqumrehsnnvbzqwlibdbtajliydtvfstedwbtn) |
+|    2 | 2026-04-13 12:42:08 | 49274275 | [rbofvssfgdugxfkkmfralrsxctcfsxjmazlgjpqyscvqlpavwuqnrdidpaee](https://explorer.qubic.org/network/tx/rbofvssfgdugxfkkmfralrsxctcfsxjmazlgjpqyscvqlpavwuqnrdidpaee) |
+|    3 | 2026-04-13 12:44:10 | 49274485 | [xjsgrunttnukbdamdbfmmlyfmytgvofrmlpirihnjgazcuwhdpmxemkghxda](https://explorer.qubic.org/network/tx/xjsgrunttnukbdamdbfmmlyfmytgvofrmlpirihnjgazcuwhdpmxemkghxda) |
+
+## Compensation
+
+To compensate MEXC for the losses, a dedicated wallet was created:
+- **Address**: [JXSQGHDICVEBEAGVGFTSSNUORXLCEBBROYMXHTPYDEIPBMXQRFPFYNPFMVUN](https://explorer.qubic.org/network/address/JXSQGHDICVEBEAGVGFTSSNUORXLCEBBROYMXHTPYDEIPBMXQRFPFYNPFMVUN)
+
+### Funding Sources
+
+| Source                  |     Amount (Qubic) | TX                                                                                                                                                                 | Notes                                                                                    |
+| :---------------------- | -----------------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------- |
+| QCT treasury            |     13'391'819'438 | [tkjfwrbmupgjncjoukqdjevknctfsdlfnoaylvozhdjmwstokggwuuehvblj](https://explorer.qubic.org/network/tx/tkjfwrbmupgjncjoukqdjevknctfsdlfnoaylvozhdjmwstokggwuuehvblj) | Covered from QCT budget                                                                  |
+| Recovered from end user |      3'946'979'934 | [rlphsxaobclbaccdlxgohxbfdaafgyuzzykhrczafcuyzyqcvdfnruchayjo](https://explorer.qubic.org/network/tx/rlphsxaobclbaccdlxgohxbfdaafgyuzzykhrczafcuyzyqcvdfnruchayjo) | Group 1 — end user was identified and business development negotiated a voluntary refund |
+| **Total**               | **17'338'799'372** |                                                                                                                                                                    |                                                                                          |
+
+### Compensation Payment to MEXC
+
+The total of `17'338'799'372 Qubic` was transferred from the dedicated wallet to the MEXC address (VUEYKUCYYHXKDGOSCWAIEECECDBCXVUSUAJRVXUQVAQPGIOABLGGLXDAXTNK):
+- **TX**: [quykovxsrcwpebnsglflqkwzkxaepzzrtxfloyrjkfibhxwmchgstazbzfek](https://explorer.qubic.org/network/tx/quykovxsrcwpebnsglflqkwzkxaepzzrtxfloyrjkfibhxwmchgstazbzfek)


### PR DESCRIPTION
## Summary
Adds the Q2 2026 financial reporting and the related vulnerability entry.

- **March 2026** financial report
- **April 2026** financial report — includes the 17.04.2026 one-off treasury reimbursement (`Other Transfers`) linked to QVE-2026-0001
- **May 2026** financial report — balances reflect the reimbursement carried over from April; funding-proposal note in the Current Balance section
- **QVE-2026-0001** — ecosystem-wide transaction-status data processing incident (Query API false failure status), with impact, root cause, mitigation, and compensation details

## Notes
- Treasury balances and budget usage match the actual on-chain state (`99'561'316'171 Qubic` after May payments).
- The April reimbursement is recorded once (in the April report) and reflected in the May carried-over balance.